### PR TITLE
:zap: chore: migrate to signals

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:signals/signals_flutter.dart';
 
 import 'sample_feature/sample_item_details_view.dart';
 import 'sample_feature/sample_item_list_view.dart';
@@ -22,9 +23,8 @@ class MyApp extends StatelessWidget {
     //
     // The ListenableBuilder Widget listens to the SettingsController for changes.
     // Whenever the user updates their settings, the MaterialApp is rebuilt.
-    return ListenableBuilder(
-      listenable: settingsController,
-      builder: (BuildContext context, Widget? child) {
+    return Watch(
+      (BuildContext context) {
         return MaterialApp(
           // Providing a restorationScopeId allows the Navigator built by the
           // MaterialApp to restore the navigation stack when a user leaves and
@@ -58,7 +58,7 @@ class MyApp extends StatelessWidget {
           // SettingsController to display the correct theme.
           theme: ThemeData(),
           darkTheme: ThemeData.dark(),
-          themeMode: settingsController.themeMode,
+          themeMode: settingsController.themeMode.value,
 
           // Define a function to handle named routes in order to support
           // Flutter web url navigation and deep linking.

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -27,7 +27,7 @@ class SettingsView extends StatelessWidget {
         // SettingsController is updated, which rebuilds the MaterialApp.
         child: DropdownButton<ThemeMode>(
           // Read the selected themeMode from the controller
-          value: controller.themeMode,
+          value: controller.themeMode.value,
           // Call the updateThemeMode method any time the user selects a theme.
           onChanged: controller.updateThemeMode,
           items: const [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -128,6 +128,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
+  signals:
+    dependency: "direct main"
+    description:
+      name: signals
+      sha256: "6ae589ba9dc2d0dea44c8f1345e3f9f7a6ffb71009a4acb49e46ffdf41c77f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -199,3 +207,4 @@ packages:
     version: "0.3.0"
 sdks:
   dart: ">=3.2.0 <4.0.0"
+  flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   mocktail: ^1.0.1
+  signals: ^1.4.1
 
 dev_dependencies:
   flutter_test:

--- a/test/src/settings/settings_controller_test.dart
+++ b/test/src/settings/settings_controller_test.dart
@@ -24,7 +24,7 @@ void main() {
       await settingsController.loadSettings();
 
       // Assert
-      expect(settingsController.themeMode, ThemeMode.dark);
+      expect(settingsController.themeMode.value, ThemeMode.dark);
       // Verify notifyListeners was called, you might need a way to check this
     });
 
@@ -44,7 +44,7 @@ void main() {
       await settingsController.updateThemeMode(ThemeMode.light);
 
       // Assert
-      expect(settingsController.themeMode, ThemeMode.light);
+      expect(settingsController.themeMode.value, ThemeMode.light);
       // Verify notifyListeners was called
       verify(() => mockSettingsService.updateThemeMode(ThemeMode.light))
           .called(1);

--- a/test/src/settings/settings_view_test.dart
+++ b/test/src/settings/settings_view_test.dart
@@ -11,12 +11,12 @@ void main() {
       (WidgetTester tester) async {
     // Arrange
     final mockService = MockSettingsService();
-    final mockController = SettingsController(mockService);
-
     when(() => mockService.themeMode())
         .thenAnswer((_) => Future.value(ThemeMode.system));
     when(() => mockService.updateThemeMode(ThemeMode.light))
         .thenAnswer((_) => Future.value());
+
+    final mockController = SettingsController(mockService);
 
     await mockController.loadSettings();
     await tester.pumpWidget(MaterialApp(
@@ -26,7 +26,7 @@ void main() {
     await mockController.loadSettings();
 
     // Initial state check
-    expect(mockController.themeMode,
+    expect(mockController.themeMode.value,
         equals(ThemeMode.system)); // Assuming this is the default
 
     // Act: Open dropdown and select 'Light Theme'
@@ -37,6 +37,6 @@ void main() {
     await tester.pumpAndSettle(); // Wait for the dropdown to close
 
     // Assert
-    expect(mockController.themeMode, equals(ThemeMode.light));
+    expect(mockController.themeMode.value, equals(ThemeMode.light));
   });
 }


### PR DESCRIPTION
This PR would likely not be merged. It exist to show how signals compare with regular changenotifiers.

Of course, the existing tests were maintained.