### PR TITLE
💡 Demo - migrate to state_beacon

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:state_beacon/state_beacon.dart';
 
 import 'sample_feature/sample_item_details_view.dart';
 import 'sample_feature/sample_item_list_view.dart';
@@ -58,7 +59,7 @@ class MyApp extends StatelessWidget {
           // SettingsController to display the correct theme.
           theme: ThemeData(),
           darkTheme: ThemeData.dark(),
-          themeMode: settingsController.themeMode,
+          themeMode: settingsController.themeMode.watch(context),
 
           // Define a function to handle named routes in order to support
           // Flutter web url navigation and deep linking.

--- a/lib/src/settings/settings_controller.dart
+++ b/lib/src/settings/settings_controller.dart
@@ -36,7 +36,7 @@ class SettingsController with ChangeNotifier {
     if (newThemeMode == null) return;
 
     // Do not perform any work if new and old ThemeMode are identical
-    if (newThemeMode == _themeMode) return;
+    if (newThemeMode == _themeMode.value) return;
 
     // Otherwise, store the new ThemeMode in memory
     _themeMode.value = newThemeMode;

--- a/lib/src/settings/settings_controller.dart
+++ b/lib/src/settings/settings_controller.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:state_beacon/state_beacon.dart';
 
 import 'settings_service.dart';
 
@@ -13,18 +14,18 @@ class SettingsController with ChangeNotifier {
   // Make SettingsService a private variable so it is not used directly.
   final SettingsService _settingsService;
 
-  // Make ThemeMode a private variable so it is not updated directly without
-  // also persisting the changes with the SettingsService.
-  late ThemeMode _themeMode;
+  // LazyWritable behaves like a `late` variable, it must be initialized before use.
+  // this way you can get type safety without setting the initial value to null.
+  final _themeMode = Beacon.lazyWritable<ThemeMode>();
 
-  // Allow Widgets to read the user's preferred ThemeMode.
-  ThemeMode get themeMode => _themeMode;
+  // Exposes it as a readable beacon so it cannot be changed from outside the controller.
+  ReadableBeacon<ThemeMode> get themeMode => _themeMode;
 
   /// Load the user's settings from the SettingsService. It may load from a
   /// local database or the internet. The controller only knows it can load the
   /// settings from the service.
   Future<void> loadSettings() async {
-    _themeMode = await _settingsService.themeMode();
+    _themeMode.value = await _settingsService.themeMode();
 
     // Important! Inform listeners a change has occurred.
     notifyListeners();
@@ -38,7 +39,7 @@ class SettingsController with ChangeNotifier {
     if (newThemeMode == _themeMode) return;
 
     // Otherwise, store the new ThemeMode in memory
-    _themeMode = newThemeMode;
+    _themeMode.value = newThemeMode;
 
     // Important! Inform listeners a change has occurred.
     notifyListeners();

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -27,7 +27,7 @@ class SettingsView extends StatelessWidget {
         // SettingsController is updated, which rebuilds the MaterialApp.
         child: DropdownButton<ThemeMode>(
           // Read the selected themeMode from the controller
-          value: controller.themeMode,
+          value: controller.themeMode.value,
           // Call the updateThemeMode method any time the user selects a theme.
           onChanged: controller.updateThemeMode,
           items: const [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,6 +149,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
+  state_beacon:
+    dependency: "direct main"
+    description:
+      name: state_beacon
+      sha256: "037e304f93389c1ef4615c7d0c7c49f1bd3846033f13cdd44f224cb93fe0cad0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.2"
   stream_channel:
     dependency: transitive
     description:
@@ -199,3 +207,4 @@ packages:
     version: "0.3.0"
 sdks:
   dart: ">=3.2.0 <4.0.0"
+  flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,32 +2,33 @@ name: coinpay
 description: "A new Flutter project showcasing how to tests using the flutter skeleton template"
 
 # Prevent accidental publishing to pub.dev.
-publish_to: 'none'
+publish_to: "none"
 
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
+    sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
-  flutter_localizations:
-    sdk: flutter
-  mocktail: ^1.0.1
+    flutter:
+        sdk: flutter
+    flutter_localizations:
+        sdk: flutter
+    mocktail: ^1.0.1
+    state_beacon: ^0.9.2
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
+    flutter_test:
+        sdk: flutter
 
-  flutter_lints: ^2.0.0
+    flutter_lints: ^2.0.0
 
 flutter:
-  uses-material-design: true
+    uses-material-design: true
 
-  # Enable generation of localized Strings from arb files.
-  generate: true
+    # Enable generation of localized Strings from arb files.
+    generate: true
 
-  assets:
-    # Add assets from the images directory to the application.
-    - assets/images/
+    assets:
+        # Add assets from the images directory to the application.
+        - assets/images/

--- a/test/src/settings/settings_controller_test.dart
+++ b/test/src/settings/settings_controller_test.dart
@@ -24,7 +24,7 @@ void main() {
       await settingsController.loadSettings();
 
       // Assert
-      expect(settingsController.themeMode, ThemeMode.dark);
+      expect(settingsController.themeMode.value, ThemeMode.dark);
       // Verify notifyListeners was called, you might need a way to check this
     });
 
@@ -44,7 +44,7 @@ void main() {
       await settingsController.updateThemeMode(ThemeMode.light);
 
       // Assert
-      expect(settingsController.themeMode, ThemeMode.light);
+      expect(settingsController.themeMode.value, ThemeMode.light);
       // Verify notifyListeners was called
       verify(() => mockSettingsService.updateThemeMode(ThemeMode.light))
           .called(1);

--- a/test/src/settings/settings_view_test.dart
+++ b/test/src/settings/settings_view_test.dart
@@ -26,7 +26,7 @@ void main() {
     await mockController.loadSettings();
 
     // Initial state check
-    expect(mockController.themeMode,
+    expect(mockController.themeMode.value,
         equals(ThemeMode.system)); // Assuming this is the default
 
     // Act: Open dropdown and select 'Light Theme'
@@ -37,6 +37,6 @@ void main() {
     await tester.pumpAndSettle(); // Wait for the dropdown to close
 
     // Assert
-    expect(mockController.themeMode, equals(ThemeMode.light));
+    expect(mockController.themeMode.value, equals(ThemeMode.light));
   });
 }


### PR DESCRIPTION
This is just a demonstration of my pkg ([state_beacon](https://pub.dev/packages/state_beacon)). I think it's a bit cleaner with the use of a `lazyWritable`...which is a signal that behaves like a `late` variable (has to be initialized before it's read), so you don't have to set the value upfront.